### PR TITLE
Switch the framebuffer to 16-bit color

### DIFF
--- a/c_src/main.c
+++ b/c_src/main.c
@@ -87,13 +87,12 @@ void init_video_core( egl_data_t* p_data, int debug_mode ) {
   p_data->major_version = major_version;
   p_data->minor_version = minor_version;
 
-
   // prepare an appropriate EGL frame buffer configuration request
   static const EGLint attribute_list[] = {
-    EGL_RED_SIZE, 8,
-    EGL_GREEN_SIZE, 8,
-    EGL_BLUE_SIZE, 8,
-    EGL_ALPHA_SIZE, 8,
+    EGL_RED_SIZE, 5,
+    EGL_GREEN_SIZE, 6,
+    EGL_BLUE_SIZE, 5,
+    EGL_ALPHA_SIZE, 0,
     EGL_STENCIL_SIZE, 1,
     EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
     EGL_NONE


### PR DESCRIPTION
Based on shaky Google searches, there was a suggestion that 16-bit color worked better with the Raspberry Pi VC4. I thought that I saw an improvement on one run, but I'm not convinced this did anything on recent runs.