### PR TITLE
Don't render NULL characters

### DIFF
--- a/c_src/render_script.c
+++ b/c_src/render_script.c
@@ -648,7 +648,8 @@ void* text( NVGcontext* p_ctx, void* p_script ) {
     start = rows[nrows-1].next;
   }
 
-  return p_script + text_info->size;
+  // Text is padded to 32-bits
+  return p_script + ((text_info->size + 3) & ~3);
 }
 
 

--- a/lib/rpi/compile.ex
+++ b/lib/rpi/compile.ex
@@ -1005,15 +1005,15 @@ defmodule Scenic.Driver.Nerves.Rpi.Compile do
   end
 
   defp op_text(ops, text) do
-    text_size = byte_size(text) + 1
+    text_size = byte_size(text)
 
     # keep everything aligned on 4 byte boundaries
-    {text_size, extra_buffer} =
-      case 4 - rem(text_size, 4) do
-        1 -> {text_size + 1, <<0::size(8)>>}
-        2 -> {text_size + 2, <<0::size(16)>>}
-        3 -> {text_size + 3, <<0::size(24)>>}
-        _ -> {text_size, <<>>}
+    padding_size =
+      case rem(text_size, 4) do
+        0 -> 0
+        1 -> 24
+        2 -> 16
+        3 -> 8
       end
 
     [
@@ -1021,9 +1021,7 @@ defmodule Scenic.Driver.Nerves.Rpi.Compile do
         @op_text::unsigned-integer-size(32)-native,
         text_size::unsigned-integer-size(32)-native,
         text::binary,
-        # null terminate the string so it can be used directly
-        0::size(8),
-        extra_buffer::binary
+        0::size(padding_size)
       >>
       | ops
     ]


### PR DESCRIPTION
The PressStart2P font renders NULL bytes as question marks and makes
this issue easy to see. The number of question marks that you'd see
varied depending on the length of the text. This was due to the text
being padded with NULL bytes and the text length including the NULL
bytes.

This changes the port interface to pass the text length unmodified so
that the real text length can be passed to NanoVG.  It still adds
padding characters to keep 32-bit alignment. The port rounds the text
length up to account for the padding.